### PR TITLE
Add recursive directory searching. Skip non-text files.

### DIFF
--- a/src/blog/layout.py
+++ b/src/blog/layout.py
@@ -27,9 +27,9 @@ class Layout:
     def get_all(layouts_dir):
         layouts = {}
 
+        print(layouts_dir)
         for file in fs.get_files_in_dir(layouts_dir):
-            path = os.path.join(layouts_dir, file)
-            layout = Layout(path)
+            layout = Layout(file)
             layouts[layout.name] = layout
 
         return layouts

--- a/src/lib/fs.py
+++ b/src/lib/fs.py
@@ -9,7 +9,7 @@ from shutil import copyfile
 def change_ext(ext: str, file_path: str):
     """Changes extension in path"""
     pre, _ = os.path.splitext(file_path)
-    return pre + '.' + ext
+    return pre + "." + ext
 
 
 def rm_dir(directory: str):
@@ -32,16 +32,16 @@ def copy_dir(source: str, dest: str):
 
 
 def get_files_in_dir(dir: str, filter_partials=False):
-    """returns files from given dir with optional partials filtering"""
-    file_names = [
-        f for f in os.listdir(dir) if os.path.isfile(os.path.join(dir, f))
-    ]
-
-    if filter_partials:
-        file_names = filter(
-            lambda f: not f.startswith('_', 0, -1),
-            file_names,
-        )
+    """recursively returns files from given dir with optional partials filtering"""
+    file_names = []
+    for root, dirs, files in os.walk(dir):
+        dirs[:] = [f for f in dirs if not f.startswith(".")]
+        if filter_partials:
+            files = filter(
+                lambda f: not f.startswith("_", 0, -1),
+                files,
+            )
+        file_names.extend(os.path.join(root, f) for f in files)
 
     return file_names
 
@@ -57,7 +57,7 @@ def copy_file(src: str, dest: str):
 
 def write_file(dest, content):
     os.makedirs(os.path.dirname(dest), exist_ok=True)
-    with open(dest, 'a') as f:
+    with open(dest, "a") as f:
         print(content, file=f)
 
 
@@ -71,11 +71,11 @@ def load(filename):
         f = frontmatter.load(filename)
         return [filename, f.metadata, f.content]
     except Exception as error:
-        print(f'[ERROR] There is an error loading {filename}: {error}')
-        exit(1)
+        print(f"[ERROR] There is an error loading {filename}: {error}")
+        raise
 
 
 def normalize_path(path: str):
-    if path[0] == '/':
+    if path[0] == "/":
         return os.path.realpath(path)
     return path

--- a/src/obsidian/page.py
+++ b/src/obsidian/page.py
@@ -27,21 +27,19 @@ class Page:
     def __init__(self, data: ContentData):
         self.data = data
         self.head = self.build_tree()
-        self.data.entities = list(
-            map(TreeNode.unwrap, self.head.flat_children())
-        )
+        self.data.entities = list(map(TreeNode.unwrap, self.head.flat_children()))
 
     @staticmethod
     def get_all(pages_dir):
         pages = []
 
-        for file in fs.get_files_in_dir(pages_dir):
-            path = os.path.join(pages_dir, file)
-            filename, meta, content = fs.load(path)
+        for file in fs.get_files_in_dir(pages_dir, filter_partials=True):
+            try:
+                filename, meta, content = fs.load(file)
+            except UnicodeDecodeError as e:
+                continue
 
-            content_data = ContentData(
-                filename=filename, meta=meta, content=content
-            )
+            content_data = ContentData(filename=filename, meta=meta, content=content)
 
             page = Page(content_data)
             pages.append(page)
@@ -67,7 +65,7 @@ class Page:
         if context == None:
             context = {}
         content = self.data.content
-        if self.data.ext == '.md':
+        if self.data.ext == ".md":
             content = self.render_entities()
             content = markdown.render(content)
         try:
@@ -77,13 +75,13 @@ class Page:
 
     def render_entities(self):
         for entity in self.data.entities:
-            if hasattr(entity, 'render'):
+            if hasattr(entity, "render"):
                 data = entity.data
-                if hasattr(data, 'is_private') and data.is_private:
-                    if data.content != '':
+                if hasattr(data, "is_private") and data.is_private:
+                    if data.content != "":
                         print(data.content)
                         print(
-                            f'  - [SKIP]: {data.placeholder} is private, add `published: True` attribute to the frontmetter to publish it'
+                            f"  - [SKIP]: {data.placeholder} is private, add `published: True` attribute to the frontmetter to publish it"
                         )
                         continue
                 self.data.content = entity.render(self.data)


### PR DESCRIPTION
Adds support for finding published notes in folders within the vault by making `fs.get_files_in_dir` a recursive search.

I also added some error handling so that image files etc. are skipped over.
